### PR TITLE
Add Music Disc Recipes

### DIFF
--- a/datapack.md
+++ b/datapack.md
@@ -58,3 +58,30 @@
 | 1 Minecart with Hopper  | 10 Iron Ingot |    `Vanilla`     |
 | 1 Minecart with Chest   |  1 Minecart   |    `Vanilla`     |
 | 1 Minecart with Furnace |  1 Minecart   |    `Vanilla`     |
+
+### Music Discs
+
+- 2 Music Disc = 1 Music Disc (Next)
+- Example: 2 Music Disc (13) = 1 Music Disc (cat)
+- Based on track order
+
+1. 13
+2. cat
+3. blocks
+4. chirp
+5. far
+6. mall
+7. mellohi
+8. stal
+9. strad
+10. ward
+11. 11
+12. wait
+13. otherside
+14. 5
+15. Pigstep
+16. Relic
+17. Creator
+18. Creator (Music Box)
+19. Precipice
+20. Tears

--- a/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_10_ward_to_11.json
+++ b/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_10_ward_to_11.json
@@ -1,0 +1,8 @@
+{
+	"type": "crafting_shapeless",
+	"ingredients": ["music_disc_ward", "music_disc_ward"],
+	"result": {
+		"id": "music_disc_11",
+		"count": 1
+	}
+}

--- a/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_11_11_to_wait.json
+++ b/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_11_11_to_wait.json
@@ -1,0 +1,8 @@
+{
+  "type": "crafting_shapeless",
+  "ingredients": ["music_disc_11", "music_disc_11"],
+  "result": {
+    "id": "music_disc_wait",
+    "count": 1
+  }
+}

--- a/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_12_wait_to_otherside.json
+++ b/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_12_wait_to_otherside.json
@@ -1,0 +1,8 @@
+{
+  "type": "crafting_shapeless",
+  "ingredients": ["music_disc_wait", "music_disc_wait"],
+  "result": {
+    "id": "music_disc_otherside",
+    "count": 1
+  }
+}

--- a/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_13_otherside_to_5.json
+++ b/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_13_otherside_to_5.json
@@ -1,0 +1,8 @@
+{
+  "type": "crafting_shapeless",
+  "ingredients": ["music_disc_otherside", "music_disc_otherside"],
+  "result": {
+    "id": "music_disc_5",
+    "count": 1
+  }
+}

--- a/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_14_5_to_pigstep.json
+++ b/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_14_5_to_pigstep.json
@@ -1,0 +1,8 @@
+{
+  "type": "crafting_shapeless",
+  "ingredients": ["music_disc_5", "music_disc_5"],
+  "result": {
+    "id": "music_disc_pigstep",
+    "count": 1
+  }
+}

--- a/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_15_pigstep_to_relic.json
+++ b/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_15_pigstep_to_relic.json
@@ -1,0 +1,8 @@
+{
+  "type": "crafting_shapeless",
+  "ingredients": ["music_disc_pigstep", "music_disc_pigstep"],
+  "result": {
+    "id": "music_disc_relic",
+    "count": 1
+  }
+}

--- a/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_16_relic_to_creator.json
+++ b/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_16_relic_to_creator.json
@@ -1,0 +1,8 @@
+{
+  "type": "crafting_shapeless",
+  "ingredients": ["music_disc_relic", "music_disc_relic"],
+  "result": {
+    "id": "music_disc_creator",
+    "count": 1
+  }
+}

--- a/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_17_creator_to_creator_music_box.json
+++ b/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_17_creator_to_creator_music_box.json
@@ -1,0 +1,8 @@
+{
+  "type": "crafting_shapeless",
+  "ingredients": ["music_disc_creator", "music_disc_creator"],
+  "result": {
+    "id": "music_disc_creator_music_box",
+    "count": 1
+  }
+}

--- a/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_18_creator_music_box_to_precipice.json
+++ b/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_18_creator_music_box_to_precipice.json
@@ -1,0 +1,8 @@
+{
+  "type": "crafting_shapeless",
+  "ingredients": ["music_disc_creator_music_box", "music_disc_creator_music_box"],
+  "result": {
+    "id": "music_disc_precipice",
+    "count": 1
+  }
+}

--- a/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_19_precipice_to_tears.json
+++ b/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_19_precipice_to_tears.json
@@ -1,0 +1,8 @@
+{
+  "type": "crafting_shapeless",
+  "ingredients": ["music_disc_precipice", "music_disc_precipice"],
+  "result": {
+    "id": "music_disc_tears",
+    "count": 1
+  }
+}

--- a/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_1_13_to_cat.json
+++ b/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_1_13_to_cat.json
@@ -1,0 +1,8 @@
+{
+  "type": "crafting_shapeless",
+  "ingredients": ["music_disc_13", "music_disc_13"],
+  "result": {
+    "id": "music_disc_cat",
+    "count": 1
+  }
+}

--- a/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_20_tears_to_lava_chicken.json
+++ b/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_20_tears_to_lava_chicken.json
@@ -1,0 +1,8 @@
+{
+  "type": "crafting_shapeless",
+  "ingredients": ["music_disc_tears", "music_disc_tears"],
+  "result": {
+    "id": "music_disc_lava_chicken",
+    "count": 1
+  }
+}

--- a/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_2_cat_to_blocks.json
+++ b/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_2_cat_to_blocks.json
@@ -1,0 +1,8 @@
+{
+  "type": "crafting_shapeless",
+  "ingredients": ["music_disc_cat", "music_disc_cat"],
+  "result": {
+    "id": "music_disc_blocks",
+    "count": 1
+  }
+}

--- a/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_3_blocks_to_chirp.json
+++ b/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_3_blocks_to_chirp.json
@@ -1,0 +1,8 @@
+{
+  "type": "crafting_shapeless",
+  "ingredients": ["music_disc_blocks", "music_disc_blocks"],
+  "result": {
+    "id": "music_disc_chirp",
+    "count": 1
+  }
+}

--- a/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_4_chirp_to_far.json
+++ b/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_4_chirp_to_far.json
@@ -1,0 +1,8 @@
+{
+  "type": "crafting_shapeless",
+  "ingredients": ["music_disc_chirp", "music_disc_chirp"],
+  "result": {
+    "id": "music_disc_far",
+    "count": 1
+  }
+}

--- a/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_5_far_to_mall.json
+++ b/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_5_far_to_mall.json
@@ -1,0 +1,8 @@
+{
+  "type": "crafting_shapeless",
+  "ingredients": ["music_disc_far", "music_disc_far"],
+  "result": {
+    "id": "music_disc_mall",
+    "count": 1
+  }
+}

--- a/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_6_mall_to_mellohi.json
+++ b/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_6_mall_to_mellohi.json
@@ -1,0 +1,8 @@
+{
+  "type": "crafting_shapeless",
+  "ingredients": ["music_disc_mall", "music_disc_mall"],
+  "result": {
+    "id": "music_disc_mellohi",
+    "count": 1
+  }
+}

--- a/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_7_mellohi_to_stal.json
+++ b/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_7_mellohi_to_stal.json
@@ -1,0 +1,8 @@
+{
+  "type": "crafting_shapeless",
+  "ingredients": ["music_disc_mellohi", "music_disc_mellohi"],
+  "result": {
+    "id": "music_disc_stal",
+    "count": 1
+  }
+}

--- a/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_8_stal_to_strad.json
+++ b/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_8_stal_to_strad.json
@@ -1,0 +1,8 @@
+{
+	"type": "crafting_shapeless",
+	"ingredients": ["music_disc_stal", "music_disc_stal"],
+	"result": {
+		"id": "music_disc_strad",
+		"count": 1
+	}
+}

--- a/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_9_strad_to_ward.json
+++ b/datapack/data/vmpyrc_vmc/recipe/crafting/music_discs/music_disc_9_strad_to_ward.json
@@ -1,0 +1,8 @@
+{
+	"type": "crafting_shapeless",
+	"ingredients": ["music_disc_strad", "music_disc_strad"],
+	"result": {
+		"id": "music_disc_ward",
+		"count": 1
+	}
+}


### PR DESCRIPTION
### Music Discs

- 2 Music Disc = 1 Music Disc (Next)
- Example: 2 Music Disc (13) = 1 Music Disc (cat)
- Based on track order

1. 13
2. cat
3. blocks
4. chirp
5. far
6. mall
7. mellohi
8. stal
9. strad
10. ward
11. 11
12. wait
13. otherside
14. 5
15. Pigstep
16. Relic
17. Creator
18. Creator (Music Box)
19. Precipice
20. Tears
